### PR TITLE
Remove old news from README.md

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,22 +2,6 @@
 Aldjemy
 =======
 
-Whats new?
-----------
-
-2011-12-15:
-
-- Add M2M models generations. Storing them on core.Cache.models.
-
-2011-12-14:
-
-- Added M2M fields generation. Now we dont generate models for m2m tables.
-- Sqlite datetime double conversion fix
-
-Before:
-
-- mixins support
-
 Base
 ----
 


### PR DESCRIPTION
The old news were misleading because they suggest that this project has been last updated in 2011. It seems to me that actually this projects is alive and actively maintained.