### PR TITLE
Add aldjemy.meta.AldjemyMeta for easier mixins

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,3 +87,28 @@ To integrate it with aldjemy models you can put these methods into a separate mi
 
 Voilà! You can use `unicode` on aldjemy classes, because this mixin will be
 mixed into generated aldjemy model.
+
+If you want to expose all methods and properties without creating a
+separate mixin class, you can use the `aldjemy.meta.AldjemyMeta`
+metaclass::
+
+    from aldjemy.meta import AldjemyMeta
+
+    class Task(models.Model):
+        code = models.CharField(_('code'), max_length=32, unique=True)
+
+        def __unicode__(self):
+            return self.code
+
+        __metaclass__ = AldjemyMeta
+
+The result is same as with the example above, only you didn't need to
+create the mixin class at all.
+
+Also note that with Python 3, the syntax is a bit different::
+
+    class Task(models.Model, metaclass=AldjemyMeta):
+        code = models.CharField(_('code'), max_length=32, unique=True)
+
+        def __str__(self):
+            return self.code

--- a/aldjemy/meta.py
+++ b/aldjemy/meta.py
@@ -1,0 +1,20 @@
+from django.db.base import ModelBase
+
+
+class AldjemyMeta(ModelBase):
+    '''Add methods and properties to the SQLAlchemy mapping'''
+
+    def __new__(cls, name, bases, attrs, **kwds):
+        new_class = ModelBase.__new__(cls, name, bases, attrs, **kwds)
+
+        aldjemy_attrs = {}
+        for name, attr in attrs.items():
+            if callable(attr) or isinstance(attr, property):
+                aldjemy_attrs[name] = attr
+
+        new_class.aldjemy_mixin = type(
+            'AldjemyMixin_' + name, (object,),
+            aldjemy_attrs,
+        )
+
+        return new_class


### PR DESCRIPTION
Using this metaclass, all callables and properties get exposed
automatically and you don't need to create a separate mixin class.