### PR TITLE
Optionally skip adding SQLAlchemy backrefs

### DIFF
--- a/aldjemy/orm.py
+++ b/aldjemy/orm.py
@@ -46,7 +46,7 @@ def _extract_model_attrs(model, sa_models):
         p_table = tables[parent_model.db_table]
         p_name = parent_model.pk.column
 
-        disable_backref = True if fk.rel.related_name and fk.rel.related_name.endswith('+') else False
+        disable_backref = fk.rel.related_name and fk.rel.related_name.endswith('+')
         backref = (fk.rel.related_name.lower().strip('+')
                    if fk.rel.related_name else None)
         if not backref and not disable_backref:

--- a/aldjemy/orm.py
+++ b/aldjemy/orm.py
@@ -46,9 +46,10 @@ def _extract_model_attrs(model, sa_models):
         p_table = tables[parent_model.db_table]
         p_name = parent_model.pk.column
 
+        disable_backref = True if fk.rel.related_name and fk.rel.related_name.endswith('+') else False
         backref = (fk.rel.related_name.lower().strip('+')
                    if fk.rel.related_name else None)
-        if not backref:
+        if not backref and not disable_backref:
             backref = model._meta.object_name.lower()
             if not isinstance(fk, OneToOneField):
                 backref = backref + '_set'
@@ -72,9 +73,10 @@ def _extract_model_attrs(model, sa_models):
                 primaryjoin=(table.c[fk.column] == p_table.c[p_name]),
                 remote_side=p_table.c[p_name],
                 )
+            if backref:
+                kw.update(backref=backref)
         attrs[fk.name] = orm.relationship(
                 sa_models[parent_model.db_table],
-                backref=backref,
                 **kw
                 )
     return attrs


### PR DESCRIPTION
Do not add SQLAlchemy backrefs to relationships if the Django field name ends with '+' (eg: duplicate Django's ORM behavior).

Note that this is off-the-cuff, and completely untested.

Hopefully closes #14.