### PR TITLE
Fixes for SQLAlchemy 1.0.6 compatibility.

### DIFF
--- a/aldjemy/core.py
+++ b/aldjemy/core.py
@@ -9,6 +9,8 @@ from .table import generate_tables
 from .wrapper import Wrapper
 from .sqlite import SqliteWrapper
 
+import time
+
 
 __all__ = ['get_engine', 'get_meta', 'get_tables']
 
@@ -94,6 +96,7 @@ class _ConnectionRecord(_ConnectionRecordBase):
         self.__pool = pool
         self.info = {}
         self.finalize_callback = deque()
+        self.starttime = time.time()
 
         self.alias = alias
         self.wrap = False

--- a/aldjemy/core.py
+++ b/aldjemy/core.py
@@ -118,7 +118,7 @@ class _ConnectionRecord(_ConnectionRecordBase):
     def close(self):
         pass
 
-    def invalidate(self, e=None):
+    def invalidate(self, e=None, soft=False):
         pass
 
     def get_connection(self):


### PR DESCRIPTION
This addresses the new comment for #15 as well as issue #29 .

Since it just sets up a property in the `_ConnectRecord` initializer and adds a keyword argument to `invalidate()`, it won't have any backwards compatibility issues with previous SQLAlchemy versions.
