### PR TITLE
Added python 3 to classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setupconf = dict(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
         ],
     )
 


### PR DESCRIPTION
by doing that, djangopackages.org can mark this package as python3 ready. Also pypi analyses will also show this package as python3 ready
