### PR TITLE
A fix for sqlalchemy.exc.ArgumentError in prepare_models

### DIFF
--- a/aldjemy/core.py
+++ b/aldjemy/core.py
@@ -1,3 +1,4 @@
+import warnings
 from collections import deque
 from django.db import connections
 from django.conf import settings
@@ -15,8 +16,19 @@ import time
 __all__ = ['get_engine', 'get_meta', 'get_tables']
 
 
+class CacheType(type):
+
+    def __getattribute__(cls, name):
+        if name == 'models':
+            warnings.warn('Cache.models attribute is deprecated. '
+                          'Use Cache.sa_models instead.',
+                          DeprecationWarning, stacklevel=2)
+        return type.__getattribute__(cls, name)
+
+
 class Cache(object):
     """Module level cache"""
+    __metaclass__ = CacheType
     engines = {}
 
 

--- a/aldjemy/orm.py
+++ b/aldjemy/orm.py
@@ -91,9 +91,11 @@ def _extract_model_attrs(model, sa_models):
 
 
 def prepare_models():
+
     tables = get_tables()
     models = get_django_models()
-    sa_models = {}
+
+    sa_models = getattr(Cache, 'models', {})
 
     for model in models:
         name = model._meta.db_table
@@ -114,6 +116,8 @@ def prepare_models():
         name = model._meta.db_table
         orm.mapper(sa_models[model], table, attrs)
         model.sa = sa_models[model]
+
+    Cache.models = sa_models
 
 
 class BaseSQLAModel(object):

--- a/test_project/sample/models.py
+++ b/test_project/sample/models.py
@@ -25,6 +25,11 @@ class StaffAuthor(Author):
     date = models.DateTimeField()
 
 
+class StaffAuthorProxy(Author):
+    class Meta:
+        proxy = True
+
+
 class Review(models.Model):
     book = models.ForeignKey('a_sample.BookProxy')
 

--- a/test_project/sample/tests.py
+++ b/test_project/sample/tests.py
@@ -4,7 +4,8 @@ if sys.version_info[0] == 3:
 
 from django.test import TestCase
 from django.contrib.auth import get_user_model
-from sample.models import Chapter, Book, Author, StaffAuthor, Review
+from sample.models import (
+    Chapter, Book, Author, StaffAuthor, StaffAuthorProxy, Review)
 from a_sample.models import BookProxy
 
 
@@ -17,6 +18,7 @@ class SimpleTest(TestCase):
         self.assertTrue(Book.sa)
         self.assertTrue(Author.sa)
         self.assertTrue(StaffAuthor.sa)
+        self.assertTrue(StaffAuthorProxy.sa)
         self.assertTrue(Review.sa)
         self.assertTrue(BookProxy.sa)
         self.assertTrue(User.sa)


### PR DESCRIPTION
This pull request aims to resolve an exception
```
sqlalchemy.exc.ArgumentError: Class '<class 'aldjemy.orm.C'>' already has a primary mapper defined. Use non_primary=True to create a non primary Mapper.  clear_mappers() will remove *all* current mappers from all classes.
```
in **prepare_models** function when it deals with a proxy model inherited from another model sub-type.

In particular this fix supports the following inheritance scenario:

```
    class A(model.Model):
        pass

    class B(A):
        pass

    class C(B):
        class Meta:
            proxy = True
```