### PR TITLE
Fix bug with backrefs on OneToOne fields

### DIFF
--- a/aldjemy/orm.py
+++ b/aldjemy/orm.py
@@ -62,6 +62,8 @@ def _extract_model_attrs(model, sa_models):
             backref = model._meta.object_name.lower()
             if not isinstance(fk, OneToOneField):
                 backref = backref + '_set'
+        elif backref and isinstance(fk, OneToOneField):
+            backref = orm.backref(backref, uselist=False)
 
         kw = {}
         if isinstance(fk, ManyToManyField):


### PR DESCRIPTION
The 'uselist' parameter to backref should be False for OneToOneFields as per http://docs.sqlalchemy.org/en/latest/orm/basic_relationships.html#one-to-one. Otherwise, calling the backref accessor on the model will return an InstrumentedList