### PR TITLE
orm: Map non-related fields too, to make them accessible by name

### DIFF
--- a/aldjemy/orm.py
+++ b/aldjemy/orm.py
@@ -45,6 +45,13 @@ def _extract_model_attrs(model, sa_models):
              if isinstance(t, (ForeignKey, OneToOneField))]
     attrs = {}
     rel_fields = fks + list(model._meta.many_to_many)
+
+    for f in model._meta.fields:
+        if not isinstance(f, (ForeignKey, OneToOneField)):
+            if f.model != model:
+                continue  # Fields from parent model are not supported
+            attrs[f.name] = orm.column_property(table.c[f.column])
+
     for fk in rel_fields:
         if not fk.column in table.c and not isinstance(fk, ManyToManyField):
             continue


### PR DESCRIPTION
By default in Django the column name in database is chosen based on field name in model. However it is possible to override the column name using the [`db_column`][1] property.

In our project we use quite obscure column names like `F_ARTICLE_NAME` when the field name is just `name`. In Aldjemy ORM, we want to use the field name, not the column name. Without this change, it is only possible for related keys (such as ForeignKey and OneToOneField), but not for normal keys.

[1]: https://docs.djangoproject.com/en/dev/ref/models/fields/#db-column