### PR TITLE
Ignore missing columns

### DIFF
--- a/aldjemy/orm.py
+++ b/aldjemy/orm.py
@@ -49,7 +49,7 @@ def _extract_model_attrs(metadata, model, sa_models):
 
     for f in model._meta.fields:
         if not isinstance(f, (ForeignKey, OneToOneField)):
-            if f.model != model:
+            if f.model != model or f.column not in table.c:
                 continue  # Fields from parent model are not supported
             attrs[f.name] = orm.column_property(table.c[f.column])
 

--- a/test.sh
+++ b/test.sh
@@ -11,7 +11,7 @@ if [ "$PY27_DJANGO17" = "0" ]; then
     while getopts ":p" opt; do
         case $opt in
             p)
-                pip install psycopg2==2.6.2
+                pip install psycopg2
                 cd ../test_project_postgres
                 python manage.py test
                 EXIT2=$?

--- a/test_project_postgres/sample/models.py
+++ b/test_project_postgres/sample/models.py
@@ -1,6 +1,10 @@
 from django.db import models
-from django.contrib.postgres.fields import ArrayField
+from django.contrib.postgres.fields import ArrayField, JSONField
 
 
 class TicTacToeBoard(models.Model):
     board = ArrayField(models.TextField(), size=9)
+
+
+class JsonModel(models.Model):
+    value = JSONField()

--- a/test_project_postgres/sample/tests.py
+++ b/test_project_postgres/sample/tests.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 from sqlalchemy.dialects.postgresql import array
-from sample.models import TicTacToeBoard
+from sample.models import TicTacToeBoard, JsonModel
 
 
 class TestArrayField(TestCase):
@@ -29,3 +29,11 @@ class TestArrayField(TestCase):
         assert query.filter(contains('x')).count() == 2
         assert query.filter(contains('o')).count() == 2
         assert query.filter(contains(' ')).count() == 3
+
+
+class TestJsonField(TestCase):
+    def test_model_creates(self):
+        """
+        It's important that the field not cause the project to fail startup.
+        """
+        assert JsonModel.sa is not None

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,8 @@
 [tox]
-envlist = {py27,py35,py36}-django{18,19,110,111},{py35,py36}-django20, py27-django17
+envlist =
+    {py27,py35,py36}-django{18,19,110,111}
+    {py35,py36}-django{20,21}
+    py27-django17
 
 [testenv]
 commands = ./test.sh {posargs}
@@ -10,7 +13,8 @@ deps =
      django19: django==1.9.13
      django110: django==1.10.7
      django111: django==1.11.2
-     django20: django==2.0b1
+     django20: django==2.0.9
+     django21: django==2.1.3
      six==1.10.0
      sqlalchemy==1.0.12
 setenv =


### PR DESCRIPTION
I'm not sure exactly why my field isn't in the columns it's looking up, but it's a `django.contrib.postgres.fields.JSONField`, and it likely has something to do with that. Anyway, just checking to ensure it is indeed in the dict of columns is good enough to solve the issue for me.

Fixes #65 