### PR TITLE
Support configuring sqlalchemy with custom json_deserializer 

### DIFF
--- a/aldjemy/core.py
+++ b/aldjemy/core.py
@@ -52,18 +52,17 @@ def get_connection_string(alias='default'):
     return engine + '://' + options
 
 
-def get_engine(alias='default'):
+def get_engine(alias='default', **kwargs):
     if alias not in Cache.engines:
         engine_string = get_engine_string(alias)
         # we have to use autocommit=True, because SQLAlchemy
         # is not aware of Django transactions
-        kw = {}
         if engine_string == 'sqlite3':
-            kw['native_datetime'] = True
+            kwargs['native_datetime'] = True
 
         pool = DjangoPool(alias=alias, creator=None)
         Cache.engines[alias] = create_engine(get_connection_string(alias),
-                                             pool=pool, **kw)
+                                             pool=pool, **kwargs)
     return Cache.engines[alias]
 
 

--- a/aldjemy/orm.py
+++ b/aldjemy/orm.py
@@ -11,10 +11,10 @@ from .core import get_meta, get_engine, Cache
 from .table import get_django_models, generate_tables
 
 
-def get_session(alias='default', recreate=False):
+def get_session(alias='default', recreate=False, **kwargs):
     connection = connections[alias]
     if not hasattr(connection, 'sa_session') or recreate:
-        engine = get_engine(alias)
+        engine = get_engine(alias, **kwargs)
         session = orm.sessionmaker(bind=engine)
         connection.sa_session = session()
     return connection.sa_session


### PR DESCRIPTION
This PR provides the ability for external clients to provide json_deserializer. This custom json_deserializer will then be used to configure sqlalchemy json_deserializer